### PR TITLE
更新了事件本身，使所有事件继承于一个基类。更新了事件的执行与注册函数，使其缩减到一个。删除了大量的冗余代码。

### DIFF
--- a/pvzclass/LevelEvent.cpp
+++ b/pvzclass/LevelEvent.cpp
@@ -2,66 +2,7 @@
 #include <iostream>
 
 int wave;
-void EventHandler::InvokeLevelOpenEvent()
-{
-	int lim = FunctionLevelOpenEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelOpenEventHigh[i]())
-			return;
-	lim = FunctionLevelOpenEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelOpenEventMid[i]())
-			return;
-	lim = FunctionLevelOpenEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelOpenEventLow[i]())
-			return;
-}
-void EventHandler::InvokeLevelCloseEvent()
-{
-	int lim = FunctionLevelCloseEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelCloseEventHigh[i]())
-			return; 
-	lim = FunctionLevelOpenEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelCloseEventMid[i]())
-			return;
-	lim = FunctionLevelCloseEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelCloseEventLow[i]())
-			return;
-}
-void EventHandler::InvokeLevelWaveEvent(int wave)
-{
-	int lim = FunctionLevelWaveEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelWaveEventHigh[i](wave))
-			return;
-	lim = FunctionLevelWaveEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelWaveEventMid[i](wave))
-			return;
-	lim = FunctionLevelWaveEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelWaveEventLow[i](wave))
-			return;
-}
-void EventHandler::InvokeLevelStartEvent()
-{
-	int lim = FunctionLevelStartEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelStartEventHigh[i]())
-			return;
-	lim = FunctionLevelStartEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelStartEventMid[i]())
-			return;
-	lim = FunctionLevelStartEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionLevelStartEventLow[i]())
-			return;
-}
+
 void EventHandler::UpdateLevels()
 {
 	//std::cerr << address << " " << pvz->BaseAddress << std::endl;
@@ -69,14 +10,14 @@ void EventHandler::UpdateLevels()
 	{
 		Address = pvz->BaseAddress;
 		wave = pvz->WaveCount;
-		InvokeLevelOpenEvent();
+		InvokeEvent(new EventLevelOpen(),true);
 	}
 	//std::cerr << address << "!" << pvz->BaseAddress << std::endl;
 	if (Address != NULL && pvz->BaseAddress == NULL)
 	{
 		Address = NULL;
 		IsStarted = 0;
-		InvokeLevelCloseEvent();
+		InvokeEvent(new EventLevelClose(),true);
 	}
 	if (Address)
 	{
@@ -85,52 +26,13 @@ void EventHandler::UpdateLevels()
 		if (!IsStarted && pvz->GameState == 3)
 		{
 			IsStarted = 1;
-			InvokeLevelStartEvent();
+			InvokeEvent(new EventLevelStart(),true);
 		}
 
 		if (wave != pvz->RefreshedWave)
 		{
 			wave = pvz->RefreshedWave;
-			InvokeLevelWaveEvent(wave);
+			InvokeEvent(new EventLevelWave(wave),true);
 		}
 	}
-}
-void EventHandler::RegisterLevelOpenEvent(bool function(), int level)
-{
-	if (level == Event_Low)
-		FunctionLevelOpenEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionLevelOpenEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionLevelOpenEventHigh.push_back(function);
-}
-
-void EventHandler::RegisterLevelCloseEvent(bool function(), int level)
-{
-	if (level == Event_Low)
-		FunctionLevelCloseEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionLevelCloseEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionLevelCloseEventHigh.push_back(function);
-}
-
-void EventHandler::RegisterLevelWaveEvent(bool function(int), int level)
-{
-	if (level == Event_Low)
-		FunctionLevelWaveEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionLevelWaveEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionLevelWaveEventHigh.push_back(function);
-}
-
-void EventHandler::RegisterLevelStartEvent(bool function(), int level)
-{
-	if (level == Event_Low)
-		FunctionLevelStartEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionLevelStartEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionLevelStartEventHigh.push_back(function);
 }

--- a/pvzclass/PlantEvent.cpp
+++ b/pvzclass/PlantEvent.cpp
@@ -16,52 +16,6 @@ std::vector<Plant*> EventHandler::GetAllPlants()
 	return rt;
 }
 
-void EventHandler::InvokePlantPlantEvent(Plant* plant)
-{
-	int lim = FunctionPlantPlantEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionPlantPlantEventHigh[i](plant))
-			return;
-	lim = FunctionPlantPlantEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionPlantPlantEventMid[i](plant))
-			return;
-	lim = FunctionPlantPlantEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionPlantPlantEventLow[i](plant))
-			return;
-}
-
-void EventHandler::InvokePlantRemoveEvent(Plant* plant)
-{
-	int lim = FunctionPlantRemoveEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionPlantRemoveEventHigh[i](plant))
-			return;
-	lim = FunctionPlantRemoveEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionPlantRemoveEventMid[i](plant))
-			return;
-	lim = FunctionPlantRemoveEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionPlantRemoveEventLow[i](plant))
-			return;
-}
-void EventHandler::InvokePlantUpgradeEvent(Plant* plant)
-{
-	int lim = FunctionPlantUpgradeEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionPlantUpgradeEventHigh[i](plant))
-			return;
-	lim = FunctionPlantUpgradeEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionPlantUpgradeEventMid[i](plant))
-			return;
-	lim = FunctionPlantUpgradeEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionPlantUpgradeEventLow[i](plant))
-			return;
-}
 struct pair
 {
 	int first, second;
@@ -79,6 +33,7 @@ bool operator < (pair a, pair b)
 {
 	return a.first == b.first ? a.second < b.second : a.first < b.first;
 }
+
 void EventHandler::UpdatePlants()
 {
 	if (!Address)
@@ -106,21 +61,17 @@ void EventHandler::UpdatePlants()
 		if (ok)
 		{
 			//that means didn't found current x in last. fire event PlantPlantEvent
-			if (x->Type >= PlantType::GatlingPea && x->Type < PlantType::CobCannon)
-			{
-				//DO NOT PLANT TOO MANY PLANTS IN ONE PLACE
-				std::cerr << x->Row << " " << x->Column << std::endl;
-				pardon.insert(pair(x->Row, x->Column));
-				InvokePlantUpgradeEvent(x);
-			}
-			else if (x->Type == PlantType::CobCannon)
+			if (x->Type >= PlantType::GatlingPea && x->Type <= PlantType::CobCannon)
 			{
 				pardon.insert(pair(x->Row, x->Column));
-				pardon.insert(pair(x->Row, x->Column + 1));
-				InvokePlantUpgradeEvent(x);
+				if(x->Type == PlantType::CobCannon)
+				{
+					pardon.insert(pair(x->Row, x->Column + 1));
+				}
+				InvokeEvent(new EventPlantUpgrade(x),true);
 			}
 			else
-				InvokePlantPlantEvent(x);
+				InvokeEvent(new EventPlantPlant(x),true);
 		}
 	}
 	//if (pardon.size())std::cerr << "LIST:" << std::endl;
@@ -142,43 +93,11 @@ void EventHandler::UpdatePlants()
 			if (!pardon.count(pair(x->Row, x->Column)))
 			{
 				//std::cerr << "didn't find\n";
-				InvokePlantRemoveEvent(x);
+				InvokeEvent(new EventPlantRemove(x),true);
 			}
 		}
 	}
 	pardon.clear();
 	PlantList.clear();
 	PlantList = plant;
-}
-
-
-
-void EventHandler::RegisterPlantPlantEvent(bool function(Plant*), int level)
-{
-	if(level==Event_Low)
-		FunctionPlantPlantEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionPlantPlantEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionPlantPlantEventHigh.push_back(function);
-}
-
-void EventHandler::RegisterPlantRemoveEvent(bool function(Plant*), int level)
-{
-	if (level == Event_Low)
-		FunctionPlantRemoveEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionPlantRemoveEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionPlantRemoveEventHigh.push_back(function);
-}	
-
-void EventHandler::RegisterPlantUpgradeEvent(bool function(Plant*), int level)
-{
-	if (level == Event_Low)
-		FunctionPlantUpgradeEventLow.push_back(function);
-	else if(level == Event_Mid)
-		FunctionPlantUpgradeEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionPlantUpgradeEventHigh.push_back(function);
 }

--- a/pvzclass/ProjectileEvent.cpp
+++ b/pvzclass/ProjectileEvent.cpp
@@ -1,35 +1,6 @@
 #include "events.h"
 #include <vector>
-void EventHandler::InvokeProjectileFireEvent(Projectile* projectile)
-{
-	int lim = FunctionProjectileFireEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionProjectileFireEventHigh[i](projectile))
-			return; 
-	lim = FunctionProjectileFireEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionProjectileFireEventMid[i](projectile))
-			return;
-	lim = FunctionProjectileFireEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionProjectileFireEventLow[i](projectile))
-			return;
-}
-void EventHandler::InvokeProjectileRemoveEvent(Projectile * projectile)
-{
-	int lim = FunctionProjectileRemoveEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionProjectileRemoveEventHigh[i](projectile))
-			return; 
-	lim = FunctionLevelStartEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionProjectileRemoveEventMid[i](projectile))
-			return;
-	lim = FunctionProjectileRemoveEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionProjectileRemoveEventLow[i](projectile))
-			return;
-}
+
 std::vector<Projectile*> EventHandler::GetAllProjectiles()
 {
 	std::vector<Projectile*> rt;
@@ -61,7 +32,7 @@ void EventHandler::UpdateProjectiles()
 				break;
 			}
 		if (ok)
-			InvokeProjectileFireEvent(x);
+			InvokeEvent(new EventProjectileFire(x),true);
 	}
 	for (int i = 0; i < lastn; i++)
 	{
@@ -74,27 +45,8 @@ void EventHandler::UpdateProjectiles()
 				break;
 			}
 		if (ok)
-			InvokeProjectileRemoveEvent(x);
+			InvokeEvent(new EventProjectileRemove(x),true);
 	}
 	ProjectileList.clear();
 	ProjectileList = list;
-}
-
-void EventHandler::RegisterProjectileFireEvent(bool function(Projectile*), int level)
-{
-	if (level == Event_Low)
-		FunctionProjectileFireEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionProjectileFireEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionProjectileFireEventHigh.push_back(function);
-}
-void EventHandler::RegisterProjectileRemoveEvent(bool function(Projectile*), int level)
-{
-	if (level == Event_Low)
-		FunctionProjectileRemoveEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionProjectileRemoveEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionProjectileRemoveEventHigh.push_back(function);
 }

--- a/pvzclass/ZombieEvent.cpp
+++ b/pvzclass/ZombieEvent.cpp
@@ -12,68 +12,6 @@ std::vector<Zombie*> EventHandler::GetAllZombies()
 	return rt;
 }
 
-void EventHandler::InvokeZombieSpawnEvent(Zombie* zombie)
-{
-	int lim = FunctionZombieSpawnEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieSpawnEventHigh[i](zombie))
-			return; 
-	lim = FunctionZombieSpawnEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieSpawnEventMid[i](zombie))
-			return;
-	lim = FunctionZombieSpawnEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieSpawnEventLow[i](zombie))
-			return;
-}
-void EventHandler::InvokeZombieRemoveEvent(Zombie* zombie)
-{
-	int lim = FunctionZombieRemoveEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieRemoveEventHigh[i](zombie))
-			return; 
-	lim = FunctionZombieRemoveEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieRemoveEventMid[i](zombie))
-			return;
-	lim = FunctionZombieRemoveEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieRemoveEventLow[i](zombie))
-			return;
-}
-void EventHandler::InvokeZombieDeadEvent(Zombie* zombie)
-{
-	int lim = FunctionZombieDeadEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieDeadEventHigh[i](zombie))
-			return; 
-	lim = FunctionZombieDeadEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieDeadEventMid[i](zombie))
-			return;
-	lim = FunctionZombieDeadEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieDeadEventLow[i](zombie))
-			return;
-}
-
-void EventHandler::InvokeZombieHypnotizedEvent(Zombie* zombie)
-{
-	int lim = FunctionZombieHypnotizedEventHigh.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieHypnotizedEventHigh[i](zombie))
-			return;
-	lim = FunctionZombieHypnotizedEventMid.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieHypnotizedEventMid[i](zombie))
-			return;
-	lim = FunctionZombieHypnotizedEventLow.size();
-	for (int i = 0; i < lim; i++)
-		if (FunctionZombieHypnotizedEventLow[i](zombie))
-			return;
-}
-
 bool isPostedZombieDead[10000] = {};
 bool isPostedZombieHypnotized[10000] = {};
 
@@ -96,7 +34,7 @@ void EventHandler::UpdateZombies()
 		if (x->NotExist && !isPostedZombieDead[x->Index])
 		{
 			isPostedZombieDead[x->Index] = true;
-			InvokeZombieDeadEvent(x);
+			InvokeEvent(new EventZombieDead(x),true);
 		}
 	}
 	now = GetAllZombies();
@@ -116,7 +54,7 @@ void EventHandler::UpdateZombies()
 		if (ok)
 		{
 			//didn't found x in last, spawns
-			InvokeZombieSpawnEvent(x);
+			InvokeEvent(new EventZombieSpawn(x),true);
 		}
 
 		if (x->Hypnotized)
@@ -124,7 +62,7 @@ void EventHandler::UpdateZombies()
 			if (!isPostedZombieHypnotized[x->Index])
 			{
 				isPostedZombieHypnotized[x->Index] = true;
-				InvokeZombieHypnotizedEvent(x);
+				InvokeEvent(new EventZombieHypnotized(x),true);
 			}
 		}
 	}
@@ -141,63 +79,9 @@ void EventHandler::UpdateZombies()
 		if (ok)
 		{
 			//didn't found x in now, remove
-			InvokeZombieRemoveEvent(x);
-		}
-	}
-	for (int i = 0; i < nown; i++)
-	{
-		bool ok = 1;
-		Zombie* x = now[i];
-
-		for (int j = 0; j < lastn; j++)
-			if (x->BaseAddress == ZombieList[j]->BaseAddress)
-			{
-				ok = 0;
-				break;
-			}
-		if (ok)
-		{
-			//didn't found x in last, spawns
-			InvokeZombieSpawnEvent(x);
+			InvokeEvent(new EventZombieRemove(x),true);
 		}
 	}
 	ZombieList.clear();
 	ZombieList = now;
-}
-void EventHandler::RegisterZombieSpawnEvent(bool function(Zombie*), int level)
-{
-	if (level == Event_Low)
-		FunctionZombieSpawnEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionZombieSpawnEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionZombieSpawnEventHigh.push_back(function);
-}
-void EventHandler::RegisterZombieRemoveEvent(bool function(Zombie*), int level)
-{
-	if (level == Event_Low)
-		FunctionZombieRemoveEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionZombieRemoveEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionZombieRemoveEventHigh.push_back(function);
-}
-void EventHandler::RegisterZombieDeadEvent(bool function(Zombie*), int level)
-{
-	if (level == Event_Low)
-		FunctionZombieDeadEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionZombieDeadEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionZombieDeadEventHigh.push_back(function);
-}
-
-void EventHandler::RegisterZombieHypnotizedEvent(bool function(Zombie*), int level)
-{
-	if (level == Event_Low)
-		FunctionZombieHypnotizedEventLow.push_back(function);
-	else if (level == Event_Mid)
-		FunctionZombieHypnotizedEventMid.push_back(function);
-	else if (level == Event_High)
-		FunctionZombieHypnotizedEventHigh.push_back(function);
 }

--- a/pvzclass/events.cpp
+++ b/pvzclass/events.cpp
@@ -1,0 +1,47 @@
+#include "events.h"
+
+void EventHandler::InvokeEvent(Event *event,bool isDelete)
+{
+    std::vector<listener> vec = this->listenersHigh[event->name];
+    for(int i=0;i<vec.size();i++){
+        vec[i](event);
+        if(event->CancleState){
+            return;
+        }
+    }
+    vec = this->listenersMid[event->name];
+    for(int i=0;i<vec.size();i++){
+        vec[i](event);
+        if(event->CancleState){
+            return;
+        }
+    }
+    vec = this->listenersLow[event->name];
+    for(int i=0;i<vec.size();i++){
+        vec[i](event);
+        if(event->CancleState){
+            return;
+        }
+    }
+
+    if(isDelete)
+    {
+        delete event;
+    }
+}
+ 
+void EventHandler::RegistryListeners(std::string event,listener lis,int Level)
+{
+    switch(Level)
+    {
+        case Event_Low:
+            this->listenersLow[event].push_back(lis);
+            break;
+        case Event_Mid:
+            this->listenersMid[event].push_back(lis);
+            break;
+        case Event_High:
+            this->listenersHigh[event].push_back(lis);
+            break;
+    }
+}

--- a/pvzclass/events.h
+++ b/pvzclass/events.h
@@ -2,7 +2,10 @@
 #include "PVZ.h"
 #include <vector>
 #include <queue>
+#include <string>
+#include <map>
 
+class Event;
 typedef PVZ::Plant Plant;
 typedef PVZ::Zombie Zombie;
 typedef PVZ::Projectile Projectile;
@@ -11,6 +14,7 @@ typedef std::vector<bool (*)()> vecvoid;
 typedef std::vector<bool (*)(int)> vecint;
 typedef std::vector<bool (*)(Zombie*)> veczombie;
 typedef std::vector<bool (*)(Projectile*)> vecproj;
+typedef void(*listener)(Event*);
 
 #define Event_Low 1
 #define Event_Mid 2
@@ -20,6 +24,12 @@ typedef std::vector<bool (*)(Projectile*)> vecproj;
 **testing**
 The EventHandler API
 */
+class Event
+{
+public:
+	bool CancleState;
+	std::string name;
+};
 
 class EventHandler
 {
@@ -31,65 +41,13 @@ private:
 	std::vector<Plant*> PlantList;
 	std::vector<Zombie*> ZombieList;
 	std::vector<Projectile*> ProjectileList;//wait for projectile event
+	std::map<std::string, std::vector<listener> > listenersLow;
+	std::map<std::string, std::vector<listener>> listenersMid;
+	std::map<std::string, std::vector<listener>> listenersHigh;
 	int Address;
 	bool Started;
 	bool IsStarted;
-	/*Starts the events.*/
-	vecplant    FunctionPlantPlantEventLow;
-	vecplant    FunctionPlantRemoveEventLow;
-	vecplant    FunctionPlantUpgradeEventLow;
-	vecvoid     FunctionLevelOpenEventLow;
-	vecvoid     FunctionLevelCloseEventLow;
-	vecint      FunctionLevelWaveEventLow;
-	vecvoid	    FunctionLevelStartEventLow;
-	veczombie   FunctionZombieSpawnEventLow;
-	veczombie   FunctionZombieRemoveEventLow;
-	veczombie   FunctionZombieDeadEventLow;
-	veczombie	FunctionZombieHypnotizedEventLow;
-	vecproj     FunctionProjectileFireEventLow;
-	vecproj     FunctionProjectileRemoveEventLow;
-
-	vecplant    FunctionPlantPlantEventMid;
-	vecplant    FunctionPlantRemoveEventMid;
-	vecplant    FunctionPlantUpgradeEventMid;
-	vecvoid     FunctionLevelOpenEventMid;
-	vecvoid     FunctionLevelCloseEventMid;
-	vecint      FunctionLevelWaveEventMid;
-	vecvoid	    FunctionLevelStartEventMid;
-	veczombie   FunctionZombieSpawnEventMid;
-	veczombie   FunctionZombieRemoveEventMid;
-	veczombie   FunctionZombieDeadEventMid;
-	veczombie	FunctionZombieHypnotizedEventMid;
-	vecproj     FunctionProjectileFireEventMid;
-	vecproj     FunctionProjectileRemoveEventMid;
-
-	vecplant    FunctionPlantPlantEventHigh;
-	vecplant    FunctionPlantRemoveEventHigh;
-	vecplant    FunctionPlantUpgradeEventHigh;
-	vecvoid     FunctionLevelOpenEventHigh;
-	vecvoid     FunctionLevelCloseEventHigh;
-	vecint      FunctionLevelWaveEventHigh;
-	vecvoid	    FunctionLevelStartEventHigh;
-	veczombie   FunctionZombieSpawnEventHigh;
-	veczombie   FunctionZombieRemoveEventHigh;
-	veczombie   FunctionZombieDeadEventHigh;
-	veczombie	FunctionZombieHypnotizedEventHigh;
-	vecproj     FunctionProjectileFireEventHigh;
-	vecproj     FunctionProjectileRemoveEventHigh;
-	void        InvokePlantPlantEvent(Plant*);
-	void        InvokePlantRemoveEvent(Plant*);
-	void        InvokePlantUpgradeEvent(Plant*);
-	void        InvokeLevelOpenEvent();
-	void        InvokeLevelCloseEvent();
-	void        InvokeLevelWaveEvent(int);
-	void        InvokeLevelStartEvent();
-	void        InvokeZombieSpawnEvent(Zombie*);
-	void        InvokeZombieRemoveEvent(Zombie*);
-	void	    InvokeZombieDeadEvent(Zombie*);
-	void		InvokeZombieHypnotizedEvent(Zombie*);
-	void        InvokeProjectileFireEvent(Projectile*);
-	void        InvokeProjectileRemoveEvent(Projectile*);
-	/*end of the events.*/
+	void InvokeEvent(Event *event,bool isDelete=false);
 	void Update()
 	{
 		UpdateLevels();
@@ -121,18 +79,143 @@ public:
 	}
 	/*Starts the events.*/
 	/*You should never access ANY api in Remove event.*/
-	void	RegisterPlantPlantEvent(bool function(Plant*), int level);
-	void	RegisterPlantRemoveEvent(bool function(Plant*), int level);
-	void	RegisterPlantUpgradeEvent(bool function(Plant*), int level);
-	void	RegisterLevelOpenEvent(bool function(), int level);
-	void	RegisterLevelCloseEvent(bool function(), int level);
-	void	RegisterLevelWaveEvent(bool function(int), int level);
-	void    RegisterLevelStartEvent(bool function(), int level);
-	void	RegisterZombieSpawnEvent(bool function(Zombie*), int level);
-	void	RegisterZombieDeadEvent(bool function(Zombie*), int level);
-	void	RegisterZombieHypnotizedEvent(bool function(Zombie*), int level);
-	void	RegisterZombieRemoveEvent(bool function(Zombie*), int level);
-	void    RegisterProjectileFireEvent(bool function(Projectile*), int level);
-	void    RegisterProjectileRemoveEvent(bool function(Projectile*), int level);
+	void RegistryListeners(std::string event,listener lis,int Level=Event_Low);
 	/*end of the events.*/
+};
+
+class EventPlantPlant : public Event
+{
+public:
+	Plant* plant;
+	EventPlantPlant(Plant* p)
+	{
+		name="PlantPlant";
+		plant=p;
+	}
+};
+
+class EventPlantRemove : public Event
+{
+public:
+	Plant* plant;
+	EventPlantRemove(Plant* p) 
+	{
+		name="PlantRemove";
+		plant=p;
+	}
+};
+
+class EventPlantUpgrade : public Event
+{
+public:
+	Plant* plant;
+	EventPlantUpgrade(Plant* p)
+	{
+		name="PlantUpgrade";
+		plant=p;
+	}
+};
+
+class EventLevelOpen : public Event
+{
+public:
+	EventLevelOpen()
+	{
+		name="LevelOpen";
+	}
+};
+
+class EventLevelClose : public Event
+{
+public:
+	EventLevelClose()
+	{
+		name="LevelClose";
+	}
+};
+
+class EventLevelWave : public Event
+{
+public:
+	int wave;
+	EventLevelWave(int wave)
+	{
+		this->wave=wave;
+		name="LevelWave";
+	}
+};
+
+class EventLevelStart : public Event
+{
+public:
+	EventLevelStart()
+	{
+		name="LevelStart";
+	}
+};
+
+class EventProjectileFire : public Event
+{
+public:
+	Projectile* projectile;
+	EventProjectileFire(Projectile* projectile)
+	{
+		name="ProjectileFire";
+		this->projectile = projectile;
+	}
+};
+
+class EventProjectileRemove : public Event
+{
+public:
+	Projectile* projectile;
+	EventProjectileRemove(Projectile* projectile)
+	{
+		name="ProjectileRemove";
+		this->projectile = projectile;
+	}
+};
+
+class EventZombieSpawn : public Event
+{
+public:
+	Zombie* zombie;
+	EventZombieSpawn(Zombie* zombie)
+	{
+		name="ZombieSpawn";
+		this->zombie = zombie;
+	}
+};
+
+class EventZombieRemove : public Event
+{
+public:
+	Zombie* zombie;
+	EventZombieRemove(Zombie* zombie)
+	{
+		name="ZombieRemove";
+		this->zombie = zombie;
+	}
+};
+
+class EventZombieDead : public Event
+{
+public:
+	Zombie* zombie;
+	EventZombieDead(Zombie* zombie)
+	{
+		name="ZombieDead";
+		this->zombie = zombie;
+	}
+};
+
+class EventZombieHypnotized : public Event
+{
+public:
+	Zombie* zombie;
+	EventZombieHypnotized(Zombie* zombie)
+	{
+		name="ZombieHypnotized";
+		this->zombie = zombie;
+	}
 };

--- a/pvzclass/pvzclass.cpp
+++ b/pvzclass/pvzclass.cpp
@@ -3,16 +3,15 @@
 #include "events.h"
 
 using namespace std;
-bool OnDeath(Zombie* zombie)
+void OnDeath(Event* e)
 {
-	std::cout << endl << zombie->Index;
-	return true;
+	//e->CancleState = true;
+	std::cout << endl << ((EventZombieDead*)e)->zombie->Index;
 }
 
-bool OnDeath2(Zombie* zombie)
+void OnDeath2(Event* e)
 {
-	std::cout << endl <<"2"<< zombie->Index ;
-	return true;
+	std::cout << endl <<"2 "<< ((EventZombieDead*)e)->zombie->Index;
 }
 
 int main()
@@ -29,8 +28,8 @@ int main()
 	//	return 2;
 	//EventHandler start
 	EventHandler e(pvz);
-	e.RegisterZombieDeadEvent(OnDeath, Event_High);
-	e.RegisterZombieDeadEvent(OnDeath2, Event_Low);
+	e.RegistryListeners("ZombieDead",OnDeath, Event_High);
+	e.RegistryListeners("ZombieDead",OnDeath2, Event_Low);
 	while (pvz->BaseAddress)
 	{
 		//cerr << pvz->WaveCount << " " << pvz->RefreshedWave << endl;


### PR DESCRIPTION
利用基类及指针，我使各个事件可以用同一个函数来注册监听器及触发，大大缩减了代码总量。以此删除了大量的冗余代码。
已经经过测试，可以使用。