### PR TITLE
修复了存档-读档后出现的bug

### DIFF
--- a/pvzclass/LevelEvent.cpp
+++ b/pvzclass/LevelEvent.cpp
@@ -11,6 +11,9 @@ void EventHandler::UpdateLevels()
 		Address = pvz->BaseAddress;
 		wave = pvz->WaveCount;
 		InvokeEvent(new EventLevelOpen(),true);
+		PlantList = GetAllPlants();
+		ZombieList = GetAllZombies();
+		ProjectileList = GetAllProjectiles();
 	}
 	//std::cerr << address << "!" << pvz->BaseAddress << std::endl;
 	if (Address != NULL && pvz->BaseAddress == NULL)


### PR DESCRIPTION
在关卡开始的时候预载所有僵尸和植物，避免了读档后重复触发同一Event
