### PR TITLE
优化Execute

### DIFF
--- a/pvzclass/Classes/Memory.cpp
+++ b/pvzclass/Classes/Memory.cpp
@@ -2,6 +2,8 @@
 
 HANDLE PVZ::Memory::hProcess = NULL;
 DWORD PVZ::Memory::processId = 0;
+HANDLE PVZ::Memory::hThread = NULL;
+DWORD PVZ::Memory::mainThreadId = 0;
 int PVZ::Memory::Variable = 0;
 HWND PVZ::Memory::mainwindowhandle = NULL;
 
@@ -54,9 +56,9 @@ int PVZ::Memory::Execute(byte asmCode[], int length)
 {
 	int Address = AllocMemory();
 	WriteArray<byte>(Address, asmCode, length);
-	WriteMemory<byte>(0x552014, 0xFE);
+	SuspendThread(hThread);
 	CreateThread(Address);
-	WriteMemory<byte>(0x552014, 0xDB);
+	ResumeThread(hThread);
 	FreeMemory(Address);
 	return ReadMemory<int>(Variable);
 }

--- a/pvzclass/Events/EventHandler.h
+++ b/pvzclass/Events/EventHandler.h
@@ -70,7 +70,7 @@ void EventHandler::continueDebug(int line)
 {
 	if (!ContinueDebugEvent(debugEvent.dwProcessId, debugEvent.dwThreadId, DBG_CONTINUE))
 	{
-		failLog(__LINE__, "ContinueDebugEvent failed!");
+		failLog(line, "ContinueDebugEvent failed!");
 	}
 }
 
@@ -78,7 +78,7 @@ void EventHandler::waitDebugInfinity(int line)
 {
 	if (!WaitForDebugEvent(&debugEvent, -1))
 	{
-		failLog(__LINE__, "WaitForDebugEvent failed!");
+		failLog(line, "WaitForDebugEvent failed!");
 	}
 }
 
@@ -87,7 +87,7 @@ HANDLE EventHandler::getThread(int line)
 	HANDLE hThread = OpenThread(THREAD_ALL_ACCESS, true, debugEvent.dwThreadId);
 	if (hThread == 0)
 	{
-		failLog(__LINE__, "hThread is 0!");
+		failLog(line, "hThread is 0!");
 	}
 	return hThread;
 }
@@ -96,7 +96,7 @@ void EventHandler::closeThread(HANDLE hThread, int line)
 {
 	if (!CloseHandle(hThread))
 	{
-		failLog(__LINE__, "CloseHandle failed!");
+		failLog(line, "CloseHandle failed!");
 	}
 }
 

--- a/pvzclass/PVZ.cpp
+++ b/pvzclass/PVZ.cpp
@@ -7,6 +7,15 @@ PVZ::PVZ(DWORD pid)
 	Memory::hProcess = OpenProcess(PROCESS_ALL_ACCESS, 0, pid);
 	Memory::mainwindowhandle = Memory::ReadMemory<HWND>(PVZ_BASE + 0x350);
 	Memory::Variable = Memory::AllocMemory();
+
+	DEBUG_EVENT debugEvent;
+	DebugActiveProcess(Memory::processId);
+	WaitForDebugEvent(&debugEvent, -1);
+	ContinueDebugEvent(debugEvent.dwProcessId, debugEvent.dwThreadId, DBG_CONTINUE);
+	DebugActiveProcessStop(PVZ::Memory::processId);
+
+	Memory::mainThreadId = debugEvent.dwThreadId;
+	Memory::hThread = OpenThread(THREAD_ALL_ACCESS, true, debugEvent.dwThreadId);
 }
 
 PVZ::~PVZ()

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -113,6 +113,9 @@ public:
 		static int Variable;
 		static HANDLE hProcess;
 		static DWORD processId;
+		// 主线程（第一个线程），在初始化EventHandler后赋值
+		static HANDLE hThread;
+		static DWORD mainThreadId;
 		static HWND mainwindowhandle;
 		template <class T>
 		inline static T ReadMemory(int address)

--- a/pvzclass/pvzclass.cpp
+++ b/pvzclass/pvzclass.cpp
@@ -8,11 +8,18 @@ using namespace std;
 
 PVZ* pvz;
 
+void moreZombie()
+{
+	Creator::CreateZombie(ZombieType::Zombie, 2, 9);
+}
+
 void listener(shared_ptr<PVZ::CardSlot::SeedCard> seedcard)
 {
 	cout << pvz->GetMouse()->ClickState << " ";
 	cout << seedcard->Index << " ";
 	cout << CardType::ToString(seedcard->ContentCard) << "卡槽卡片被点击了" << endl;
+	thread t(moreZombie);
+	t.detach();
 }
 
 int main()


### PR DESCRIPTION
之前的Execute是将pvz主程序设为死循环后再执行远程代码，但可能会存在执行代码的时候pvz主程序还未执行到死循环处，即pvzclass与pvz双线程同时运行，可能会出现AccessViolation的随机崩溃。

现在会在PVZ类构造的时候通过附加debug获取到pvz的主线程，执行Execute时会将pvz主线程暂停，执行完远程代码后再恢复pvz主线程，以避免可能出现的随机崩溃。

经过粗测没有大问题，需要更多测试。

另：修复了EventHandler中failLog行数错误的问题