### PR TITLE
调整了Event的部分代码，让其支持Win64构建

### DIFF
--- a/pvzclass/Events/CoinCollectEvent.h
+++ b/pvzclass/Events/CoinCollectEvent.h
@@ -17,6 +17,16 @@ CoinCollectEvent::CoinCollectEvent()
 	address = 0x432060;
 }
 
+#if defined(_WIN64)
+void CoinCollectEvent::handle(CONTEXT& context)
+{
+	auto coin = std::make_shared<PVZ::Coin>(context.Rcx);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](coin);
+	}
+}
+#else
 void CoinCollectEvent::handle(CONTEXT& context)
 {
 	auto coin = std::make_shared<PVZ::Coin>(context.Ecx);
@@ -25,3 +35,4 @@ void CoinCollectEvent::handle(CONTEXT& context)
 		listeners[i](coin);
 	}
 }
+#endif

--- a/pvzclass/Events/CoinCreateEvent.h
+++ b/pvzclass/Events/CoinCreateEvent.h
@@ -17,6 +17,16 @@ CoinCreateEvent::CoinCreateEvent()
 	address = 0x40CCCE;
 }
 
+#if defined(_WIN64)
+void CoinCreateEvent::handle(CONTEXT& context)
+{
+	auto coin = std::make_shared<PVZ::Coin>(context.Rax);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](coin);
+	}
+}
+#else
 void CoinCreateEvent::handle(CONTEXT& context)
 {
 	auto coin = std::make_shared<PVZ::Coin>(context.Eax);
@@ -25,3 +35,4 @@ void CoinCreateEvent::handle(CONTEXT& context)
 		listeners[i](coin);
 	}
 }
+#endif

--- a/pvzclass/Events/CoinRemoveEvent.h
+++ b/pvzclass/Events/CoinRemoveEvent.h
@@ -18,6 +18,16 @@ CoinRemoveEvent::CoinRemoveEvent()
 	address = 0x432DD0;
 }
 
+#if defined(_WIN64)
+void CoinRemoveEvent::handle(CONTEXT& context)
+{
+	auto coin = std::make_shared<PVZ::Coin>(context.Rsi);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](coin);
+	}
+}
+#else
 void CoinRemoveEvent::handle(CONTEXT& context)
 {
 	auto coin = std::make_shared<PVZ::Coin>(context.Esi);
@@ -26,3 +36,4 @@ void CoinRemoveEvent::handle(CONTEXT& context)
 		listeners[i](coin);
 	}
 }
+#endif

--- a/pvzclass/Events/EventHandler.h
+++ b/pvzclass/Events/EventHandler.h
@@ -30,7 +30,7 @@ public:
 	// ms至少为1，可以用-1代表无限等待
 	// 如果返回值为true，需要调用handle()和resume()
 	bool run(int ms);
-	
+
 	// 停止调试PVZ进程
 	void stop();
 
@@ -70,7 +70,7 @@ void EventHandler::continueDebug(int line)
 {
 	if (!ContinueDebugEvent(debugEvent.dwProcessId, debugEvent.dwThreadId, DBG_CONTINUE))
 	{
-		failLog(__LINE__, "ContinueDebugEvent failed!");
+		failLog(line, "ContinueDebugEvent failed!");
 	}
 }
 
@@ -78,7 +78,7 @@ void EventHandler::waitDebugInfinity(int line)
 {
 	if (!WaitForDebugEvent(&debugEvent, -1))
 	{
-		failLog(__LINE__, "WaitForDebugEvent failed!");
+		failLog(line, "WaitForDebugEvent failed!");
 	}
 }
 
@@ -87,7 +87,7 @@ HANDLE EventHandler::getThread(int line)
 	HANDLE hThread = OpenThread(THREAD_ALL_ACCESS, true, debugEvent.dwThreadId);
 	if (hThread == 0)
 	{
-		failLog(__LINE__, "hThread is 0!");
+		failLog(line, "hThread is 0!");
 	}
 	return hThread;
 }
@@ -96,7 +96,7 @@ void EventHandler::closeThread(HANDLE hThread, int line)
 {
 	if (!CloseHandle(hThread))
 	{
-		failLog(__LINE__, "CloseHandle failed!");
+		failLog(line, "CloseHandle failed!");
 	}
 }
 
@@ -120,7 +120,7 @@ bool EventHandler::run(int ms)
 	if (!WaitForDebugEvent(&debugEvent, ms))
 	{
 		return false;
-}
+	}
 	if (debugEvent.dwDebugEventCode != EXCEPTION_DEBUG_EVENT)
 	{
 		continueDebug(__LINE__);

--- a/pvzclass/Events/Events说明.md
+++ b/pvzclass/Events/Events说明.md
@@ -54,6 +54,8 @@ int listener(shared_ptr<PVZ::Zombie> zombie, DamageType::DamageType type, int am
 
 4. listener 会按照添加的先后顺序触发，请确保它们之间的正常运行逻辑。
 
+5. listener 中，使用 `Execute` 会导致程序卡死，请另开一个线程执行使用 `Execute` 的函数。
+
 ## 开发说明
 
 请参照 Events 文件夹中相关文件。

--- a/pvzclass/Events/Events说明.md
+++ b/pvzclass/Events/Events说明.md
@@ -47,10 +47,12 @@ int listener(shared_ptr<PVZ::Zombie> zombie, DamageType::DamageType type, int am
 说明几个注意点：
 
 1. 调用 start 之后，PVZ 便会在触发事件时被阻塞，直到事件被 handle.run 处理，请确保 run 的调用足够频繁，且 start 与 run 之间不会有相关事件被触发。
+
 2. run 的参数是等待时间（毫秒），如果在这期间触发了事件，则返回 true。
+
 3. 等待时间如果是 -1（INFINITY）则会阻塞住 pvzclass 直到事件触发，等待时间至少为 1ms，请根据自己的需要选择合适的等待时长。
+
 4. listener 会按照添加的先后顺序触发，请确保它们之间的正常运行逻辑。
-4. listener 中，使用 `Execute` 会导致程序卡死，请另开一个线程执行使用 `Execute` 的函数。
 
 ## 开发说明
 

--- a/pvzclass/Events/PeaOnFireEvent.h
+++ b/pvzclass/Events/PeaOnFireEvent.h
@@ -17,6 +17,16 @@ PeaOnFireEvent::PeaOnFireEvent()
 	address = 0x46ECB0;
 }
 
+#if defined(_WIN64)
+void PeaOnFireEvent::handle(CONTEXT& context)
+{
+	auto projectile = std::make_shared<PVZ::Projectile>(context.Rcx);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](projectile);
+	}
+}
+#else
 void PeaOnFireEvent::handle(CONTEXT& context)
 {
 	auto projectile = std::make_shared<PVZ::Projectile>(context.Ecx);
@@ -25,3 +35,4 @@ void PeaOnFireEvent::handle(CONTEXT& context)
 		listeners[i](projectile);
 	}
 }
+#endif

--- a/pvzclass/Events/PlantCreateEvent.h
+++ b/pvzclass/Events/PlantCreateEvent.h
@@ -17,6 +17,16 @@ PlantCreateEvent::PlantCreateEvent()
 	address = 0x40D190;
 }
 
+#if defined(_WIN64)
+void PlantCreateEvent::handle(CONTEXT& context)
+{
+	auto plant = std::make_shared<PVZ::Plant>(context.Rax);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](plant);
+	}
+}
+#else
 void PlantCreateEvent::handle(CONTEXT& context)
 {
 	auto plant = std::make_shared<PVZ::Plant>(context.Eax);
@@ -25,3 +35,4 @@ void PlantCreateEvent::handle(CONTEXT& context)
 		listeners[i](plant);
 	}
 }
+#endif

--- a/pvzclass/Events/PlantReloadEvent.h
+++ b/pvzclass/Events/PlantReloadEvent.h
@@ -20,6 +20,18 @@ PlantReloadEvent::PlantReloadEvent()
 	address = 0x45F8C4;
 }
 
+#if defined(_WIN64)
+void PlantReloadEvent::handle(CONTEXT& context)
+{
+	auto plant = std::make_shared<PVZ::Plant>(context.Rsi);
+	int cd = context.Rcx;
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		cd = listeners[i](plant, cd);
+	}
+	context.Rcx = cd;
+}
+#else
 void PlantReloadEvent::handle(CONTEXT& context)
 {
 	auto plant = std::make_shared<PVZ::Plant>(context.Esi);
@@ -30,3 +42,4 @@ void PlantReloadEvent::handle(CONTEXT& context)
 	}
 	context.Ecx = cd;
 }
+#endif

--- a/pvzclass/Events/PlantRemoveEvent.h
+++ b/pvzclass/Events/PlantRemoveEvent.h
@@ -18,6 +18,16 @@ PlantRemoveEvent::PlantRemoveEvent()
 	address = 0x4679B9;
 }
 
+#if defined(_WIN64)
+void PlantRemoveEvent::handle(CONTEXT& context)
+{
+	auto plant = std::make_shared<PVZ::Plant>(context.Rbp);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](plant);
+	}
+}
+#else
 void PlantRemoveEvent::handle(CONTEXT& context)
 {
 	auto plant = std::make_shared<PVZ::Plant>(context.Ebp);
@@ -26,3 +36,4 @@ void PlantRemoveEvent::handle(CONTEXT& context)
 		listeners[i](plant);
 	}
 }
+#endif

--- a/pvzclass/Events/PlantShootEvent.h
+++ b/pvzclass/Events/PlantShootEvent.h
@@ -17,6 +17,16 @@ PlantShootEvent::PlantShootEvent()
 	address = 0x466E0D;
 }
 
+#if defined(_WIN64)
+void PlantShootEvent::handle(CONTEXT& context)
+{
+	auto plant = std::make_shared<PVZ::Plant>(context.Rbp);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](plant);
+	}
+}
+#else
 void PlantShootEvent::handle(CONTEXT& context)
 {
 	auto plant = std::make_shared<PVZ::Plant>(context.Ebp);
@@ -25,3 +35,4 @@ void PlantShootEvent::handle(CONTEXT& context)
 		listeners[i](plant);
 	}
 }
+#endif

--- a/pvzclass/Events/ProjectileCreateEvent.h
+++ b/pvzclass/Events/ProjectileCreateEvent.h
@@ -17,6 +17,16 @@ ProjectileCreateEvent::ProjectileCreateEvent()
 	address = 0x40D652;
 }
 
+#if defined(_WIN64)
+void ProjectileCreateEvent::handle(CONTEXT& context)
+{
+	auto projectile = std::make_shared<PVZ::Projectile>(context.Rax);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](projectile);
+	}
+}
+#else
 void ProjectileCreateEvent::handle(CONTEXT& context)
 {
 	auto projectile = std::make_shared<PVZ::Projectile>(context.Eax);
@@ -25,3 +35,4 @@ void ProjectileCreateEvent::handle(CONTEXT& context)
 		listeners[i](projectile);
 	}
 }
+#endif

--- a/pvzclass/Events/ProjectileHitZombieEvent.h
+++ b/pvzclass/Events/ProjectileHitZombieEvent.h
@@ -23,6 +23,17 @@ ProjectileHitZombieEvent::ProjectileHitZombieEvent()
 	address = 0x46CE7B;
 }
 
+#if defined(_WIN64)
+void ProjectileHitZombieEvent::handle(CONTEXT& context)
+{
+	auto projectile = std::make_shared<PVZ::Projectile>(context.Rbp);
+	auto zombie = std::make_shared<PVZ::Zombie>(context.Rax);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](projectile, zombie);
+	}
+}
+#else
 void ProjectileHitZombieEvent::handle(CONTEXT& context)
 {
 	auto projectile = std::make_shared<PVZ::Projectile>(context.Ebp);
@@ -32,3 +43,4 @@ void ProjectileHitZombieEvent::handle(CONTEXT& context)
 		listeners[i](projectile, zombie);
 	}
 }
+#endif

--- a/pvzclass/Events/ProjectileRemoveEvent.h
+++ b/pvzclass/Events/ProjectileRemoveEvent.h
@@ -18,6 +18,16 @@ ProjectileRemoveEvent::ProjectileRemoveEvent()
 	address = 0x46EB20;
 }
 
+#if defined(_WIN64)
+void ProjectileRemoveEvent::handle(CONTEXT& context)
+{
+	auto projectile = std::make_shared<PVZ::Projectile>(context.Rax);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](projectile);
+	}
+}
+#else
 void ProjectileRemoveEvent::handle(CONTEXT& context)
 {
 	auto projectile = std::make_shared<PVZ::Projectile>(context.Eax);
@@ -26,3 +36,4 @@ void ProjectileRemoveEvent::handle(CONTEXT& context)
 		listeners[i](projectile);
 	}
 }
+#endif

--- a/pvzclass/Events/PuzzlePhaseCompleteEvent.h
+++ b/pvzclass/Events/PuzzlePhaseCompleteEvent.h
@@ -18,6 +18,19 @@ PuzzlePhaseCompleteEvent::PuzzlePhaseCompleteEvent()
 	address = 0x429980;
 }
 
+#if defined(_WIN64)
+void PuzzlePhaseCompleteEvent::handle(CONTEXT& context)
+{
+	auto challenge = MKS<PVZ::Miscellaneous>(PVZ::Memory::ReadMemory<DWORD>(context.Rcx + 4));
+	int gridX = context.Rax;
+	int gridY = PVZ::Memory::ReadMemory<DWORD>(context.Rsp + 4);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		gridY = listeners[i](challenge, gridX, gridY);
+	}
+	PVZ::Memory::WriteMemory<DWORD>(context.Rsp + 4, gridY);
+}
+#else
 void PuzzlePhaseCompleteEvent::handle(CONTEXT& context)
 {
 	auto challenge = MKS<PVZ::Miscellaneous>(PVZ::Memory::ReadMemory<DWORD>(context.Ecx + 4));
@@ -29,3 +42,4 @@ void PuzzlePhaseCompleteEvent::handle(CONTEXT& context)
 	}
 	PVZ::Memory::WriteMemory<DWORD>(context.Esp + 4, gridY);
 }
+#endif

--- a/pvzclass/Events/SeedCardClickEvent.h
+++ b/pvzclass/Events/SeedCardClickEvent.h
@@ -17,6 +17,16 @@ SeedCardClickEvent::SeedCardClickEvent()
 	address = 0x412236;
 }
 
+#if defined(_WIN64)
+void SeedCardClickEvent::handle(CONTEXT& context)
+{
+	auto seedcard = std::make_shared<PVZ::CardSlot::SeedCard>(context.Rax);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](seedcard);
+}
+}
+#else
 void SeedCardClickEvent::handle(CONTEXT& context)
 {
 	auto seedcard = std::make_shared<PVZ::CardSlot::SeedCard>(context.Eax);
@@ -25,3 +35,4 @@ void SeedCardClickEvent::handle(CONTEXT& context)
 		listeners[i](seedcard);
 	}
 }
+#endif

--- a/pvzclass/Events/ZombieBlastEvent.h
+++ b/pvzclass/Events/ZombieBlastEvent.h
@@ -18,6 +18,16 @@ ZombieBlastEvent::ZombieBlastEvent()
 	address = 0x532B70;
 }
 
+#if defined(_WIN64)
+void ZombieBlastEvent::handle(CONTEXT& context)
+{
+	auto zombie = std::make_shared<PVZ::Zombie>(context.Rcx);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](zombie);
+	}
+}
+#else
 void ZombieBlastEvent::handle(CONTEXT& context)
 {
 	auto zombie = std::make_shared<PVZ::Zombie>(context.Ecx);
@@ -26,3 +36,4 @@ void ZombieBlastEvent::handle(CONTEXT& context)
 		listeners[i](zombie);
 	}
 }
+#endif

--- a/pvzclass/Events/ZombieButterEvent.h
+++ b/pvzclass/Events/ZombieButterEvent.h
@@ -17,6 +17,16 @@ ZombieButterEvent::ZombieButterEvent()
 	address = 0x5326D0;
 }
 
+#if defined(_WIN64)
+void ZombieButterEvent::handle(CONTEXT& context)
+{
+	auto zombie = std::make_shared<PVZ::Zombie>(context.Rax);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](zombie);
+	}
+}
+#else
 void ZombieButterEvent::handle(CONTEXT& context)
 {
 	auto zombie = std::make_shared<PVZ::Zombie>(context.Eax);
@@ -25,3 +35,4 @@ void ZombieButterEvent::handle(CONTEXT& context)
 		listeners[i](zombie);
 	}
 }
+#endif

--- a/pvzclass/Events/ZombieDecelerateEvent.h
+++ b/pvzclass/Events/ZombieDecelerateEvent.h
@@ -17,6 +17,16 @@ ZombieDecelerateEvent::ZombieDecelerateEvent()
 	address = 0x530950;
 }
 
+#if defined(_WIN64)
+void ZombieDecelerateEvent::handle(CONTEXT& context)
+{
+	auto zombie = std::make_shared<PVZ::Zombie>(context.Rax);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](zombie);
+	}
+}
+#else
 void ZombieDecelerateEvent::handle(CONTEXT& context)
 {
 	auto zombie = std::make_shared<PVZ::Zombie>(context.Eax);
@@ -25,3 +35,4 @@ void ZombieDecelerateEvent::handle(CONTEXT& context)
 		listeners[i](zombie);
 	}
 }
+#endif

--- a/pvzclass/Events/ZombieEatEvent.h
+++ b/pvzclass/Events/ZombieEatEvent.h
@@ -17,6 +17,17 @@ ZombieEatEvent::ZombieEatEvent()
 	address = 0x52F689;
 }
 
+#if defined(_WIN64)
+void ZombieEatEvent::handle(CONTEXT& context)
+{
+	auto zombie = std::make_shared<PVZ::Zombie>(context.Rdi);
+	auto plant = std::make_shared<PVZ::Plant>(context.Rcx);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](zombie, plant);
+	}
+}
+#else
 void ZombieEatEvent::handle(CONTEXT& context)
 {
 	auto zombie = std::make_shared<PVZ::Zombie>(context.Edi);
@@ -26,3 +37,4 @@ void ZombieEatEvent::handle(CONTEXT& context)
 		listeners[i](zombie, plant);
 	}
 }
+#endif

--- a/pvzclass/Events/ZombieFrozeEvent.h
+++ b/pvzclass/Events/ZombieFrozeEvent.h
@@ -17,6 +17,16 @@ ZombieFrozeEvent::ZombieFrozeEvent()
 	address = 0x5323C0;
 }
 
+#if defined(_WIN64)
+void ZombieFrozeEvent::handle(CONTEXT& context)
+{
+	auto zombie = std::make_shared<PVZ::Zombie>(context.Rax);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](zombie);
+	}
+}
+#else
 void ZombieFrozeEvent::handle(CONTEXT& context)
 {
 	auto zombie = std::make_shared<PVZ::Zombie>(context.Eax);
@@ -25,3 +35,4 @@ void ZombieFrozeEvent::handle(CONTEXT& context)
 		listeners[i](zombie);
 	}
 }
+#endif

--- a/pvzclass/Events/ZombieHitEvent.h
+++ b/pvzclass/Events/ZombieHitEvent.h
@@ -20,6 +20,19 @@ ZombieHitEvent::ZombieHitEvent()
 	address = 0x5317C0;
 }
 
+#if defined(_WIN64)
+void ZombieHitEvent::handle(CONTEXT& context)
+{
+	auto zombie = std::make_shared<PVZ::Zombie>(context.Rsi);
+	DamageType::DamageType type = (DamageType::DamageType)(context.Rax);
+	int amount = PVZ::Memory::ReadMemory<DWORD>(context.Rsp + 4);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		amount = listeners[i](zombie, type, amount);
+	}
+	PVZ::Memory::WriteMemory<DWORD>(context.Rsp + 4, amount);
+}
+#else
 void ZombieHitEvent::handle(CONTEXT& context)
 {
 	auto zombie = std::make_shared<PVZ::Zombie>(context.Esi);
@@ -31,3 +44,4 @@ void ZombieHitEvent::handle(CONTEXT& context)
 	}
 	PVZ::Memory::WriteMemory<DWORD>(context.Esp + 4, amount);
 }
+#endif

--- a/pvzclass/Events/ZombieHypnotizeEvent.h
+++ b/pvzclass/Events/ZombieHypnotizeEvent.h
@@ -17,6 +17,16 @@ ZombieHypnotizeEvent::ZombieHypnotizeEvent()
 	address = 0x52FA60;
 }
 
+#if defined(_WIN64)
+void ZombieHypnotizeEvent::handle(CONTEXT& context)
+{
+	auto zombie = std::make_shared<PVZ::Zombie>(context.Rsi);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](zombie);
+	}
+}
+#else
 void ZombieHypnotizeEvent::handle(CONTEXT& context)
 {
 	auto zombie = std::make_shared<PVZ::Zombie>(context.Esi);
@@ -25,3 +35,4 @@ void ZombieHypnotizeEvent::handle(CONTEXT& context)
 		listeners[i](zombie);
 	}
 }
+#endif

--- a/pvzclass/Events/ZombieRemoveEvent.h
+++ b/pvzclass/Events/ZombieRemoveEvent.h
@@ -18,6 +18,16 @@ ZombieRemoveEvent::ZombieRemoveEvent()
 	address = 0x530510;
 }
 
+#if defined(_WIN64)
+void ZombieRemoveEvent::handle(CONTEXT& context)
+{
+	auto zombie = std::make_shared<PVZ::Zombie>(context.Rcx);
+	for (int i = 0; i < listeners.size(); i++)
+	{
+		listeners[i](zombie);
+	}
+}
+#else
 void ZombieRemoveEvent::handle(CONTEXT& context)
 {
 	auto zombie = std::make_shared<PVZ::Zombie>(context.Ecx);
@@ -26,3 +36,4 @@ void ZombieRemoveEvent::handle(CONTEXT& context)
 		listeners[i](zombie);
 	}
 }
+#endif

--- a/pvzclass/pvzclass.vcxproj
+++ b/pvzclass/pvzclass.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
同时项目等级变成了v143，实测能用（
实际上就是加了个编译条件，更改了对应编译下使用的方法。
例如：
#if defined(_WIN64)
void CoinCreateEvent::handle(CONTEXT& context)
{
	auto coin = std::make_shared<PVZ::Coin>(context.Rax);
	for (int i = 0; i < listeners.size(); i++)
	{
		listeners[i](coin);
	}
}
#else
void CoinCreateEvent::handle(CONTEXT& context)
{
	auto coin = std::make_shared<PVZ::Coin>(context.Eax);
	for (int i = 0; i < listeners.size(); i++)
	{
		listeners[i](coin);
	}
}
#endif