### PR TITLE
事件功能拓展

### DIFF
--- a/pvzclass/Events/ProjectileHitZombieEvent.h
+++ b/pvzclass/Events/ProjectileHitZombieEvent.h
@@ -3,7 +3,8 @@
 
 // 子弹命中僵尸事件
 // 参数：子弹与被命中的僵尸
-// 无返回值
+// 返回值：被命中的僵尸地址，0为判定未命中
+// 如果返回其它僵尸也可以做到一些有意思的事情
 class ProjectileHitZombieEvent : public DLLEvent
 {
 public:
@@ -15,6 +16,7 @@ ProjectileHitZombieEvent::ProjectileHitZombieEvent()
 	int procAddress = PVZ::Memory::GetProcAddress("onProjectileHitZombie");
 	hookAddress = 0x46CE74;
 	rawlen = 6;
-	BYTE code[] = { CMP_EAX_DWORD(0), JE(18), PUSH_EAX, PUSH_EBP, INVOKE(procAddress), ADD_ESP(8) };
+	BYTE code[] = { CMP_EAX_DWORD(0), JE(22), PUSH_EAX, PUSH_EBP,
+		INVOKE(procAddress), ADD_ESP(8), MOV_PTR_ESP_ADD_V_EUX(0, 28) };
 	start(STRING(code));
 }

--- a/pvzclass/Events/ProjectileRemoveEvent.h
+++ b/pvzclass/Events/ProjectileRemoveEvent.h
@@ -3,8 +3,9 @@
 
 // 子弹消失事件
 // 参数：消失的子弹
-// 无返回值
+// 返回值：1取消子弹消失，0子弹正常消失
 // 子弹消失的原因多种多样：命中僵尸、射出屏幕等都会触发
+// 开发时注意不要取消那些射出屏幕本该移除的子弹的消失事件
 class ProjectileRemoveEvent : public DLLEvent
 {
 public:
@@ -16,6 +17,6 @@ ProjectileRemoveEvent::ProjectileRemoveEvent()
 	int procAddress = PVZ::Memory::GetProcAddress("onProjectileRemove");
 	hookAddress = 0x46EB20;
 	rawlen = 5;
-	BYTE code[] = { PUSH_EAX, INVOKE(procAddress), ADD_ESP(4) };
+	BYTE code[] = { PUSH_EAX, INVOKE(procAddress), ADD_ESP(4), TEST_AL_AL, JE(2), POPAD, RET };
 	start(STRING(code));
 }

--- a/pvzdll/pch.cpp
+++ b/pvzdll/pch.cpp
@@ -82,15 +82,17 @@ void onProjectileCreate(DWORD projectileAddress)
 	auto projectile = std::make_shared<PVZ::Projectile>(projectileAddress);
 }
 
-void onProjectileHitZombie(DWORD projectileAddress, DWORD zombieAddress)
+DWORD onProjectileHitZombie(DWORD projectileAddress, DWORD zombieAddress)
 {
 	auto projectile = std::make_shared<PVZ::Projectile>(projectileAddress);
 	auto zombie = std::make_shared<PVZ::Zombie>(zombieAddress);
+	return zombie->GetBaseAddress();
 }
 
-void onProjectileRemove(DWORD projectileAddress)
+int onProjectileRemove(DWORD projectileAddress)
 {
 	auto projectile = std::make_shared<PVZ::Projectile>(projectileAddress);
+	return 0;
 }
 
 void onGameObjectsUpdate(DWORD boardAddress)

--- a/pvzdll/pch.h
+++ b/pvzdll/pch.h
@@ -29,8 +29,8 @@ extern "C"
 	__declspec(dllexport) void onPlantShoot(DWORD plantAddress);
 	__declspec(dllexport) void onPeaOnFire(DWORD projectileAddress);
 	__declspec(dllexport) void onProjectileCreate(DWORD projectileAddress);
-	__declspec(dllexport) void onProjectileHitZombie(DWORD projectileAddress, DWORD zombieAddress);
-	__declspec(dllexport) void onProjectileRemove(DWORD projectileAddress);
+	__declspec(dllexport) DWORD onProjectileHitZombie(DWORD projectileAddress, DWORD zombieAddress);
+	__declspec(dllexport) int onProjectileRemove(DWORD projectileAddress);
 	__declspec(dllexport) void onGameObjectsUpdate(DWORD boardAddress);
 	__declspec(dllexport) void onSeedCardClick(DWORD seedcardAddress);
 	__declspec(dllexport) void onZombieBlast(DWORD zombieAddress);


### PR DESCRIPTION
1. 子弹命中僵尸的事件可以修改命中的僵尸地址，可以使用这个方式取消命中判定或是让子弹命中另一个僵尸。
2. 子弹移除的事件增加返回值，返回值若为1可以取消子弹的移除事件。